### PR TITLE
Add mobile hamburger menu

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -88,6 +88,24 @@ nav ul {
   padding: 0;
 }
 
+/* Hamburger Toggle */
+.nav-toggle {
+  display: none;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: .5em;
+}
+
+.nav-toggle .bar {
+  display: block;
+  width: 25px;
+  height: 3px;
+  margin: 5px 0;
+  background: var(--text);
+  transition: background var(--transition);
+}
+
 nav ul li a {
   color: var(--text);
   text-decoration: none;
@@ -574,6 +592,23 @@ footer {
   .field-card, .team-card, .project-card, .beirat-card { min-width: 94vw; max-width: 97vw; }
 }
 
+@media (max-width: 750px) {
+  nav .nav-toggle { display: block; }
+  nav ul {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    background: var(--bg);
+    flex-direction: column;
+    gap: 0;
+    padding: 0.5em 1em;
+    display: none;
+    box-shadow: 0 8px 16px rgba(0,0,0,0.08);
+  }
+  nav.open ul { display: flex; }
+}
+
 @media (max-width: 570px) {
   h1 { font-size: 1.1em; }
   h2 { font-size: 1.03em; }
@@ -582,7 +617,6 @@ footer {
   .field-card, .team-card, .project-card, .beirat-card { min-width: 98vw; }
   .hero .logo-img-main { width: 160px; }
   .hero .hero-image { width: 96vw; }
-  nav ul { flex-wrap: wrap; gap: 1em; justify-content: center; }
   header { position: fixed; width: 100%; top: 0; left: 0; }
   body { padding-top: 90px; }
   .team-list, .beirat-list { justify-content: flex-start; }

--- a/index.html
+++ b/index.html
@@ -16,6 +16,11 @@
       <a class="logo" href="#">
         <img src="images/logo.png" alt="Logo" class="logo-img">
       </a>
+      <button class="nav-toggle" id="nav-toggle" aria-label="Menü öffnen" aria-expanded="false">
+        <span class="bar"></span>
+        <span class="bar"></span>
+        <span class="bar"></span>
+      </button>
       <ul>
         <li><a href="#about">Über uns</a></li>
         <li><a href="#fields">Förderfelder</a></li>

--- a/js/main.js
+++ b/js/main.js
@@ -32,3 +32,19 @@ document.getElementById('member-modal-close').onclick = function() {
 document.getElementById('member-modal-bg').onclick = function(e) {
   if (e.target === this) this.classList.remove('active');
 };
+
+// Mobile Navigation Toggle
+const nav = document.querySelector('nav');
+const navToggle = document.getElementById('nav-toggle');
+
+navToggle.addEventListener('click', () => {
+  nav.classList.toggle('open');
+  navToggle.setAttribute('aria-expanded', nav.classList.contains('open'));
+});
+
+document.querySelectorAll('nav ul a').forEach(link => {
+  link.addEventListener('click', () => {
+    nav.classList.remove('open');
+    navToggle.setAttribute('aria-expanded', 'false');
+  });
+});


### PR DESCRIPTION
## Summary
- add nav toggle button for mobile
- style new hamburger menu
- switch to a responsive menu at 750px
- close menu when links are clicked

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685d25e46a98832db09b7d7c4f044ffd