### PR TITLE
Refine link hover styling

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -5,6 +5,7 @@ html {
 :root {
   --primary: #22bfae;
   --primary-light: #eafaf8;
+  --primary-dark: #189d8c;
   --text: #222;
   --bg: #fff;
   --radius: 2em;
@@ -34,14 +35,15 @@ h1 { font-size: 3em; margin-bottom: 0.7em; }
 h2 { font-size: 2em; margin-bottom: 0.5em; }
 
 a {
-  text-decoration: none;
+  text-decoration: underline;
   color: var(--primary);
-  transition: color var(--transition);
+  transition: color var(--transition), text-shadow var(--transition);
 }
 
 a:hover,
 a:focus {
-  text-decoration: underline;
+  color: var(--primary-dark);
+  text-shadow: 0 0 1px rgba(24,157,140,0.15);
 }
 
 header {
@@ -122,6 +124,7 @@ nav ul li a:hover,
 nav ul li a.active {
   color: var(--primary);
   border-bottom: 2px solid var(--primary);
+  text-shadow: 0 0 1px rgba(24,157,140,0.15);
 }
 
 main {
@@ -499,7 +502,7 @@ section {
 
 .help-section .cta-btn:hover,
 .help-section .cta-btn:focus {
-  background: #189d8c;
+  background: var(--primary-dark);
   transform: translateY(-3px) scale(1.04);
   box-shadow: 0 12px 32px 0 rgba(34,191,174,0.16);
   text-decoration: none;


### PR DESCRIPTION
## Summary
- keep links underlined by default for better accessibility
- use subtle 1px glow on hover and active states
- prevent nav links from showing underlines on hover

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d2743c52c832d9fcee23159a0e7d9