### PR TITLE
Improve mobile team section design

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -291,6 +291,11 @@ section {
   justify-content: center;
 }
 
+/* Scroll hint arrow hidden by default */
+.scroll-hint {
+  display: none;
+}
+
 .team-card, .beirat-card {
   background: #fff;
   border-radius: var(--radius);
@@ -617,13 +622,25 @@ footer {
   h2 { font-size: 1.03em; }
   .field-card, .team-card, .project-card, .beirat-card { padding: 1.3em 0.5em; }
   .modal-card { padding: 2em 0.5em; margin: auto; }
-  .field-card, .team-card, .project-card, .beirat-card { min-width: 98vw; }
+  .field-card, .project-card { min-width: 98vw; }
+  .team-card, .beirat-card {
+    min-width: 85vw;
+    flex: 0 0 85vw;
+  }
   .hero .logo-img-main { width: 160px; }
   .hero .hero-image { width: 96vw; }
   header { position: fixed; width: 100%; top: 0; left: 0; }
   body { padding-top: 90px; }
   .team-list, .beirat-list { justify-content: flex-start; }
-  .scroll-hint { display: block; font-size: 1.5em; text-align: center; color: var(--primary); opacity: .7; animation: hintMove 2s infinite; }
+  .scroll-hint {
+    display: block;
+    font-size: 2.3em;
+    text-align: center;
+    color: var(--primary);
+    opacity: .7;
+    animation: hintMove 2s infinite;
+    margin-top: -1.2em;
+  }
 }
 
 @keyframes hintMove {

--- a/js/main.js
+++ b/js/main.js
@@ -48,3 +48,20 @@ document.querySelectorAll('nav ul a').forEach(link => {
     navToggle.setAttribute('aria-expanded', 'false');
   });
 });
+
+// Show scroll hints only when lists overflow
+function updateScrollHints() {
+  document.querySelectorAll('.team-section, .beirat-section').forEach(section => {
+    const list = section.querySelector('.team-list, .beirat-list');
+    const hint = section.querySelector('.scroll-hint');
+    if (!list || !hint) return;
+    if (list.scrollWidth > list.clientWidth) {
+      hint.style.display = '';
+    } else {
+      hint.style.display = 'none';
+    }
+  });
+}
+
+window.addEventListener('load', updateScrollHints);
+window.addEventListener('resize', updateScrollHints);


### PR DESCRIPTION
## Summary
- hide scroll hint by default and enlarge it for mobile
- adjust team card width on small screens
- show scroll hint only when the list overflows

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685d2c795e10832d8aec3813584c0990