### PR TITLE
Reduce hero spacing and refine team card wiggle

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -141,7 +141,7 @@ section {
 /* Hero Section */
 .hero {
   text-align: center;
-  padding: 1em 0 2.5em 0;
+  padding: 0.5em 0 2.5em 0;
   position: relative;
 }
 
@@ -669,7 +669,7 @@ footer {
   .hero h1 { font-size: 1.3em; }
   .hero .hero-image { width: 96vw; }
   header { position: fixed; width: 100%; top: 0; left: 0; }
-  body { padding-top: 90px; }
+  body { padding-top: 70px; }
   .team-list, .beirat-list, .projects-list { justify-content: flex-start; }
   .scroll-hint {
     display: block;
@@ -696,7 +696,7 @@ footer {
 }
 
 .team-card.wiggle {
-  animation: cardWiggle 0.5s ease-in-out 2;
+  animation: cardWiggle 1s ease-in-out;
 }
 
 

--- a/js/main.js
+++ b/js/main.js
@@ -108,7 +108,7 @@ function updateScrollHints() {
 window.addEventListener('load', updateScrollHints);
 window.addEventListener('resize', updateScrollHints);
 
-// Wiggle team cards on first visit in mobile view
+// Wiggle team cards when the section enters view on mobile
 if (window.matchMedia('(max-width: 570px)').matches) {
   const teamSection = document.querySelector('.team-section');
   if (teamSection) {
@@ -119,7 +119,6 @@ if (window.matchMedia('(max-width: 570px)').matches) {
             card.classList.add('wiggle');
             card.addEventListener('animationend', () => card.classList.remove('wiggle'), { once: true });
           });
-          observer.disconnect();
         }
       });
     }, { threshold: 0.3 });


### PR DESCRIPTION
## Summary
- Tighten hero spacing and mobile top padding to reduce excess space above the logo.
- Slow team card wiggle to a single cycle and re-trigger whenever the team section enters view on mobile.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b13a7a8f0832d97e864d3b702a99c