### PR TITLE
Add wiggle animation to beirat cards on mobile

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -697,7 +697,8 @@ footer {
   100% { transform: translateX(0); }
 }
 
-.team-card.wiggle {
+.team-card.wiggle,
+.beirat-card.wiggle {
   animation: cardWiggle 1s ease-in-out;
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -108,22 +108,25 @@ function updateScrollHints() {
 window.addEventListener('load', updateScrollHints);
 window.addEventListener('resize', updateScrollHints);
 
-// Wiggle team cards when the section enters view on mobile
+// Wiggle cards when their section enters view on mobile
 if (window.matchMedia('(max-width: 570px)').matches) {
-  const teamSection = document.querySelector('.team-section');
-  if (teamSection) {
+  const addWiggleOnView = (sectionSelector, cardSelector) => {
+    const section = document.querySelector(sectionSelector);
+    if (!section) return;
     const observer = new IntersectionObserver(entries => {
       entries.forEach(entry => {
         if (entry.isIntersecting) {
-          teamSection.querySelectorAll('.team-card').forEach(card => {
+          section.querySelectorAll(cardSelector).forEach(card => {
             card.classList.add('wiggle');
             card.addEventListener('animationend', () => card.classList.remove('wiggle'), { once: true });
           });
         }
       });
     }, { threshold: 0.3 });
-    observer.observe(teamSection);
-  }
+    observer.observe(section);
+  };
+  addWiggleOnView('.team-section', '.team-card');
+  addWiggleOnView('.beirat-section', '.beirat-card');
 }
 
 // set up email links


### PR DESCRIPTION
## Summary
- Animate beirat cards with the existing wiggle effect in mobile view
- Consolidate wiggle logic to handle both team and beirat sections

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b182b10f4832d95dc6d38b1c0bf73