### PR TITLE
Add subject to contact button email link

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,7 +180,7 @@
       <p>
         Bitte beachte, dass wir gesetzlich an die oben genannten Förderfelder gebunden sind und nur Vorhaben unterstützen können, die in diese Bereiche passen. Wirf daher vor deiner Anfrage gerne noch einmal einen Blick auf unsere <a href="#fields">Förderfelder</a>.
       </p>
-      <a class="cta-btn email" data-user="kontakt">Schreib uns</a>
+        <a class="cta-btn email" data-user="kontakt" data-subject="Projektvorschlag">Schreib uns</a>
     </section>
     <!-- Projekte -->
     <section class="projects-section" id="projects">

--- a/js/main.js
+++ b/js/main.js
@@ -6,7 +6,12 @@ function applyEmailLinks(root = document) {
     const user = el.getAttribute('data-user');
     if (!user) return;
     const email = `${user}${at}${domainParts.join('')}`;
-    el.setAttribute('href', `mailto:${email}`);
+    let href = `mailto:${email}`;
+    const subject = el.getAttribute('data-subject');
+    if (subject) {
+      href += `?subject=${encodeURIComponent(subject)}`;
+    }
+    el.setAttribute('href', href);
     if (el.classList.contains('show-email')) {
       el.textContent = email;
     }


### PR DESCRIPTION
## Summary
- include "Projektvorschlag" subject in contact button's mailto link
- support optional subject in email link generator

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b2ad15278832d832f761e3b7d68f8