### PR TITLE
Restore projects navigation and adjust team images

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -553,9 +553,13 @@ section {
   font-family: 'Montserrat', sans-serif;
   font-size: 2em;
   font-weight: 800;
-  margin-bottom: 1.4em;
+  margin-bottom: 0.5em;
   color: var(--text);
   text-align: center;
+}
+
+.projects-section .year-note {
+  margin-top: 0;
 }
 
 .projects-list {

--- a/index.html
+++ b/index.html
@@ -26,8 +26,8 @@
         <li><a href="#fields">Förderfelder</a></li>
         <li><a href="#team">Team</a></li>
         <li><a href="#donate">Spenden</a></li>
-          <li><a href="#help">Hilfe</a></li>
-          <!-- <li><a href="#projects">Projekte</a></li> -->
+        <li><a href="#help">Hilfe</a></li>
+        <li><a href="#projects">Projekte</a></li>
       </ul>
     </nav>
   </header>
@@ -110,7 +110,7 @@
       <h2>Team</h2>
       <div class="team-list">
         <div class="team-card" data-name="Heinz Kirmse" data-role="Vorstandsvorsitzender" data-img="images/portrait-heinz.jpg" data-bio="Heinz Kirmse, Jahrgang 1960, verheiratet, lebt mit Hund und Katze. Er ist sportbegeistert, engagiert sich seit Jahren im Hundeverein und ist dort auch als Hundesport-Trainer aktiv. Sein Herz schlägt für das Vereinsleben, die Nachwuchsförderung und den Tierschutz." data-user="heinz.kirmse">
-          <img src="images/portrait-heinz.jpg" alt="Heinz Kirmse">
+          <img src="images/portrait-heinz-preview.jpg" alt="Heinz Kirmse">
           <div class="name">Heinz Kirmse</div>
           <div class="role">Vorstandsvorsitzender</div>
         </div>
@@ -120,7 +120,7 @@
           <div class="role">Stellv. Vorsitzender</div>
         </div>
         <div class="team-card" data-name="Anna Schmidt" data-role="Vorstandsmitglied" data-img="images/portrait-anna.jpg" data-bio="Anna Schmidt, Jahrgang 1990, verheiratet, hat einen Hund und pflegt mit Leidenschaft ältere Ponys. Sie engagiert sich für das Miteinander und ist auch als Hundesport-Trainerin aktiv." data-user="anna.schmidt">
-          <img src="images/portrait-anna.jpg" alt="Anna Schmidt">
+          <img src="images/portrait-anna-preview.jpg" alt="Anna Schmidt">
           <div class="name">Anna Schmidt</div>
           <div class="role">Vorstandsmitglied</div>
         </div>


### PR DESCRIPTION
## Summary
- Re-add the "Projekte" section to the top navigation
- Show preview JPGs for Heinz and Anna in the team list while keeping full portraits in the modal
- Tighten spacing before the projects list by shrinking header margins

## Testing
- `npx --yes prettier index.html css/styles.css js/main.js --check` (warn: formatting issues)
- `npm test` (fails: missing `package.json`)


------
https://chatgpt.com/codex/tasks/task_e_689da863685c832d93192ae7e9aa4af8