### PR TITLE
Add IRV Dressurturnier project and tweak projects grid spacing and hover

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -682,7 +682,8 @@ section {
 .projects-list {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 320px));
-  gap: 1.8em;
+  row-gap: 1.8em;
+  column-gap: 10px;
   overflow: visible;
   padding-bottom: 0.5em;
   margin: 0 0 3em;
@@ -711,7 +712,7 @@ section {
 }
 
 .project-card:hover {
-  transform: translateY(-7px) scale(1.045);
+  transform: translateY(-7px);
   box-shadow: 0 16px 38px 0 rgba(34,191,174,0.22);
 }
 
@@ -769,7 +770,8 @@ footer a {
   nav { padding: 1.2em 1em 0.8em 1em; }
   .hero { padding: 0 0 2.8em 0; }
   h1 { font-size: 2em; }
-  .fields-list, .team-list, .projects-list, .beirat-list { gap: 1em; }
+  .fields-list, .team-list, .beirat-list { gap: 1em; }
+  .projects-list { row-gap: 1em; column-gap: 8px; }
   .field-card, .team-card, .beirat-card { min-width: 94vw; max-width: 97vw; }
 }
 

--- a/index.html
+++ b/index.html
@@ -188,11 +188,16 @@
 	  <section class="year-note" id="year-2026">
 		<h3>2026</h3>
 	  </section>
-	  <div class="projects-list">
-        <div class="project-card" data-title="Bewegte Logopädie für Tara" data-img="images/projects/tara-und-finchen.jpg" data-desc="Wir unterstützen Tara und ihre Familie bei der empfohlenen Intensivtherapie „Bewegte Logopädie“ im Allgäu. Tara wurde 2019 mit Trisomie 21 geboren und macht mit Krankengymnastik, Frühförderung, Logopädie, Ergotherapie und Reittherapie bereits schöne Fortschritte. Besonders in ihrer sprachlichen Entwicklung soll die intensive Förderwoche nun weitere Impulse geben.<br><br>Die Therapie verbindet logopädische Förderung mit Bewegung sowie tiergestützten Elementen mit Pferden. Durch diese ganzheitliche Herangehensweise kann Tara spielerisch und motivierend daran arbeiten, sich noch besser auszudrücken und aktiver am Familienalltag teilzunehmen.<br><br>Da die Kosten nicht von den Kostenträgern übernommen werden, helfen wir der Familie dabei, diese besondere Förderung möglich zu machen.">
-          <img src="images/projects/tara-und-finchen-teaser.jpg" alt="Tara mit Finchen">
-          <div class="project-title">Bewegte Logopädie für Tara</div>
-          <div class="project-desc">Unterstützung einer Intensivtherapie, die Sprachförderung, Bewegung und pferdegestützte Elemente verbindet.</div>
+		  <div class="projects-list">
+	        <div class="project-card" data-title="IRV Dressurturnier in Ingelheim" data-img="images/projects/irv-turnier-2026.png" data-desc="Am ersten Maiwochenende waren wir beim Dressurturnier des Ingelheimer Reitvereins (IRV) sportlich mit dabei. Marina Kirmse überreichte den Ehrenpreis in der Prüfung Reiterwettbewerb Schritt/Trab und durfte viele strahlende Gesichter erleben.<br><br>Auch die jüngsten Teilnehmerinnen und Teilnehmer freuten sich über einen von uns gesponserten Turnbeutel, gefüllt mit einem Outdoorspiel, Hufkratzer, etwas zum Naschen für Reiter und Pferd sowie einem kleinen Kosmetikspiegel mit integrierter Bürste. Solche Begegnungen zeigen uns immer wieder, wie viel Freude gemeinsame Unterstützung machen kann – und wir hoffen, im nächsten Jahr erneut dabei zu sein.">
+	          <img src="images/projects/irv-turnier-2026-teaser.png" alt="Ehrenpreise beim IRV Dressurturnier in Ingelheim">
+	          <div class="project-title">IRV Dressurturnier in Ingelheim</div>
+	          <div class="project-desc">Ehrenpreise für Reiterwettbewerb und Nachwuchs – mit persönlichem Engagement und viel Freude am Miteinander.</div>
+	        </div>
+	        <div class="project-card" data-title="Bewegte Logopädie für Tara" data-img="images/projects/tara-und-finchen.jpg" data-desc="Wir unterstützen Tara und ihre Familie bei der empfohlenen Intensivtherapie „Bewegte Logopädie“ im Allgäu. Tara wurde 2019 mit Trisomie 21 geboren und macht mit Krankengymnastik, Frühförderung, Logopädie, Ergotherapie und Reittherapie bereits schöne Fortschritte. Besonders in ihrer sprachlichen Entwicklung soll die intensive Förderwoche nun weitere Impulse geben.<br><br>Die Therapie verbindet logopädische Förderung mit Bewegung sowie tiergestützten Elementen mit Pferden. Durch diese ganzheitliche Herangehensweise kann Tara spielerisch und motivierend daran arbeiten, sich noch besser auszudrücken und aktiver am Familienalltag teilzunehmen.<br><br>Da die Kosten nicht von den Kostenträgern übernommen werden, helfen wir der Familie dabei, diese besondere Förderung möglich zu machen.">
+	          <img src="images/projects/tara-und-finchen-teaser.jpg" alt="Tara mit Finchen">
+	          <div class="project-title">Bewegte Logopädie für Tara</div>
+	          <div class="project-desc">Unterstützung einer Intensivtherapie, die Sprachförderung, Bewegung und pferdegestützte Elemente verbindet.</div>
         </div>
 	  </div>
       <section class="year-note" id="year-2025">


### PR DESCRIPTION
### Motivation
- Add a new 2026 project entry and refine the projects grid spacing and hover behavior to improve layout and visual consistency.

### Description
- Inserted a new project card "IRV Dressurturnier in Ingelheim" before the existing "Bewegte Logopädie für Tara" inside the 2026 `projects-list` and added its teaser image and metadata attributes.
- Replaced the single `gap` on ` .projects-list` with explicit `row-gap` and `column-gap` (desktop: `row-gap: 1.8em; column-gap: 10px`) and added responsive overrides at `@media (max-width: 950px)` (`row-gap: 1em; column-gap: 8px`).
- Simplified the hover transform on `.project-card:hover` by removing the `scale(1.045)` so the card only translates (`translateY(-7px)`), and kept the stronger hover shadow.
- Cleaned up HTML indentation/structure around the projects section to ensure the new card is nested correctly.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0718c72fc4832d872d41f7938acb3b)