### PR TITLE
Ensure project cards don't overlap by accounting for padding and increasing responsive gap

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -696,6 +696,7 @@ section {
 }
 
 .project-card {
+  box-sizing: border-box;
   background: #fff;
   border-radius: var(--radius);
   box-shadow: 0 6px 32px 0 rgba(34,191,174,0.13);
@@ -770,7 +771,7 @@ footer a {
   .hero { padding: 0 0 2.8em 0; }
   h1 { font-size: 2em; }
   .fields-list, .team-list, .beirat-list { gap: 1em; }
-  .projects-list { row-gap: 1em; column-gap: 8px; }
+  .projects-list { gap: 1.2em; }
   .field-card, .team-card, .beirat-card { min-width: 94vw; max-width: 97vw; }
 }
 


### PR DESCRIPTION
### Motivation

- Project cards on narrow screens were overlapping because their declared width did not include internal padding, and the responsive horizontal gap was too small.

### Description

- Include `box-sizing: border-box;` on `.project-card` so padding is counted in the card width and cards stay within their grid tracks.
- Use a unified responsive gap for the projects grid by setting `.projects-list { gap: 1.2em; }` inside the `@media (max-width: 950px)` rule to avoid column/row overlap on smaller viewports.

### Testing

- Ran `git diff --check` which reported no issues after the change.
- Checked repository status with `git status --short` to confirm the modified file was staged and committed locally.
- Attempted `npx --yes playwright --version` for a visual smoke check but it failed because Playwright download is blocked by the environment's package registry (HTTP 403), so no browser-based screenshot tests could be performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7f17410904832d89e7e0c6d66cf6af)